### PR TITLE
ci: Enable forks

### DIFF
--- a/.github/workflows/build_upload_whl.yml
+++ b/.github/workflows/build_upload_whl.yml
@@ -76,6 +76,7 @@ jobs:
           fetch-depth: 0
           path: ${{ inputs.SOURCE_PATH }}
           ref: ${{ inputs.BRANCH_NAME }}
+          repository: ${{ inputs.REPOSITORY_NAME }}
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -177,7 +178,7 @@ jobs:
           password: ${{ secrets.PYPI_TOKEN }}
 
       - name: Publish comment how to build .whl
-        if: inputs.RELEASE_BUILD == false
+        if: inputs.RELEASE_BUILD == false && (github.event.pull_request != null && github.event.pull_request.head.repo.full_name == github.repository) # skip for forks
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -19,7 +19,7 @@ jobs:
     secrets:
       GH_TOKEN: ${{ secrets.GH_TOKEN }}
     with:
-      REPOSITORY_NAME: ${{ github.repository }}
+      REPOSITORY_NAME: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
       BRANCH_NAME: ${{ github.head_ref }}
       PYTHON_VERSION: ${{ matrix.python_version }}
       PUSH_TAG: ${{ matrix.push_tag }}


### PR DESCRIPTION
This pull request makes updates to GitHub Actions workflows to improve compatibility with forked repositories and ensure proper repository references. The changes primarily address how repository names are handled and add conditions to avoid running certain steps in forked pull requests.

### Workflow improvements for fork compatibility:

* [`.github/workflows/build_upload_whl.yml`](diffhunk://#diff-f9a58bb8a7eca2cdffe1f8c8e5f40fc34a868f284c1101be4a24a4b729db75b2R79): Added a new `repository` input to specify the repository name explicitly in the `checkout` step.
* [`.github/workflows/build_upload_whl.yml`](diffhunk://#diff-f9a58bb8a7eca2cdffe1f8c8e5f40fc34a868f284c1101be4a24a4b729db75b2L180-R181): Updated the condition for publishing comments to skip this step for forked pull requests.
* [`.github/workflows/pull_requests.yml`](diffhunk://#diff-fe92e88acfad3a802e68589db191232e3fb44bccfc6f619aaf42ab712276a4c7L22-R22): Modified the `REPOSITORY_NAME` input to dynamically use the fork's repository name if the pull request originates from a fork, falling back to the base repository otherwise.