### PR TITLE
fix: fix regex to get vfs details properly

### DIFF
--- a/mfd_network_adapter/network_interface/feature/virtualization/linux.py
+++ b/mfd_network_adapter/network_interface/feature/virtualization/linux.py
@@ -53,7 +53,7 @@ class LinuxVirtualization(BaseFeatureVirtualization):
 
         command = f"ip link show dev {self._interface().name}"
         pattern = (
-            r"vf\s*(?P<vf_id>\d+)\s*link/ether\s*(?P<mac_address>[0-9a-fA-F]{2}(?::[0-9a-fA-F]{2}){5})\s*.*?,"
+            r"vf\s*(?P<vf_id>\d+)\s*(link/ether|MAC)\s*(?P<mac_address>[0-9a-fA-F]{2}(?::[0-9a-fA-F]{2}){5})\s*.*?,"
             r"\s*spoof checking\s*(?P<spoofchk>\w+),\s*link-state\s*(?P<link_state>\w+),\s*trust\s*("
             r"?P<trust>\w+)"
         )


### PR DESCRIPTION
This pull request makes a targeted improvement to the regular expression used for parsing virtual function (VF) details in the Linux virtualization network interface code. The update ensures the code can handle both "link/ether" and "MAC" as possible labels for MAC addresses in the output of the `ip link show` command.

Parsing robustness:

* Updated the regular expression in `_get_vfs_details` within `linux.py` to accept both `link/ether` and `MAC` as valid MAC address labels, improving compatibility with different output formats from `ip link show`.