### PR TITLE
fix: Add namespace variable to get_driver_info function for LinuxNetworkInterface object

### DIFF
--- a/mfd_network_adapter/network_interface/feature/driver/linux.py
+++ b/mfd_network_adapter/network_interface/feature/driver/linux.py
@@ -45,7 +45,10 @@ class LinuxDriver(BaseFeatureDriver):
         :return: DriverInfo dataclass that contains driver_name and driver_version.
         """
         return self.package_manager.get_driver_info(
-            self._ethtool.get_driver_information(self._interface().name).driver[0]
+            self._ethtool.get_driver_information(
+                device_name=self._interface().name,
+                namespace=self._interface().namespace,
+            ).driver[0]
         )
 
     def get_formatted_driver_version(self) -> Dict:

--- a/mfd_network_adapter/network_interface/linux.py
+++ b/mfd_network_adapter/network_interface/linux.py
@@ -69,6 +69,10 @@ class LinuxNetworkInterface(NetworkInterface):
         """Get namespace."""
         return self._interface_info.namespace
 
+    @namespace.setter
+    def namespace(self, value: Optional[str]) -> None:
+        self._interface_info.namespace = value
+
     @property
     def vsi_info(self) -> Union[VsiInfo, None]:
         """Get VSI Info."""

--- a/tests/unit/test_mfd_network_adapter/test_network_interface/test_linux_network_interface.py
+++ b/tests/unit/test_mfd_network_adapter/test_network_interface/test_linux_network_interface.py
@@ -347,3 +347,7 @@ class TestLinuxNetworkInterface:
         mock_execute.assert_called_once_with(
             f"devlink dev reload pci/{interface.pci_address}", expected_return_codes={0, 1}
         )
+
+    def test_namespace_setter(self, interface):
+        interface.namespace = "new_ns"
+        assert interface.namespace == "new_ns"


### PR DESCRIPTION
This pull request introduces improvements to how network interface namespaces are handled and passed through the codebase, particularly for retrieving driver information. The changes ensure that the namespace is correctly set and accessed, and that it is used when fetching driver details.

**Namespace handling improvements:**

* Added a setter method for the `namespace` property in the `NetworkInterface` class, allowing the namespace to be updated as needed.

**Driver information retrieval:**

* Updated the call to `_ethtool.get_driver_information` in the `get_driver_info` method to pass the interface's namespace, ensuring driver info is fetched within the correct network namespace context.