### PR TITLE
feat: Guard Get-Cluster call and log when cluster service is unavailable

### DIFF
--- a/mfd_network_adapter/network_adapter_owner/windows.py
+++ b/mfd_network_adapter/network_adapter_owner/windows.py
@@ -11,6 +11,7 @@ from time import sleep
 from typing import List, Dict, DefaultDict, Optional
 
 from mfd_common_libs import os_supported, add_logging_level, log_levels
+from mfd_connect.exceptions import ConnectionCalledProcessError
 from mfd_connect.util.powershell_utils import parse_powershell_list
 from mfd_typing import PCIDevice, OSName, VendorID, DeviceID, SubVendorID, SubDeviceID, PCIAddress, MACAddress
 from mfd_typing.network_interface import (
@@ -44,6 +45,7 @@ class WindowsNetworkAdapterOwner(NetworkAdapterOwner):
         nic_list: List[WindowsInterfaceInfo] = self._get_interfaces_and_verify_states()
         return_list: List[WindowsInterfaceInfo] = []
         is_ashci_cluster: bool = False
+        cluster_check_attempted: bool = False
 
         for nic in nic_list:
             if nic.mac_address is None:
@@ -53,8 +55,16 @@ class WindowsNetworkAdapterOwner(NetworkAdapterOwner):
             WindowsNetworkAdapterOwner._update_nic_if_virtual(nic)
 
             return_list.append(nic)
-            if nic.name.startswith("vSMB"):
-                is_ashci_cluster = True
+            if nic.name.startswith("vSMB") and not cluster_check_attempted:
+                cluster_check_attempted = True
+                try:
+                    self._connection.execute_powershell("Get-Cluster")
+                    is_ashci_cluster = True
+                except ConnectionCalledProcessError as e:
+                    logger.log(
+                        level=log_levels.MODULE_DEBUG,
+                        msg=f"Get-Cluster failed, assuming non-cluster environment: {e}",
+                    )
 
         self._update_vlan_info(nics=return_list)
         self._update_pci_addresses(nics=return_list)

--- a/tests/unit/test_mfd_network_adapter/test_network_adapter_owner/test_windows_network_owner.py
+++ b/tests/unit/test_mfd_network_adapter/test_network_adapter_owner/test_windows_network_owner.py
@@ -5,6 +5,7 @@ from textwrap import dedent
 import pytest
 from mfd_connect import RPyCConnection
 from mfd_connect.base import ConnectionCompletedProcess
+from mfd_connect.exceptions import ConnectionCalledProcessError
 from mfd_network_adapter.exceptions import NetworkAdapterModuleException
 from mfd_network_adapter.network_adapter_owner.windows import WindowsNetworkAdapterOwner
 from mfd_typing import PCIDevice, PCIAddress, OSName, VendorID, DeviceID, SubDeviceID, SubVendorID, MACAddress
@@ -450,6 +451,45 @@ class TestWindowsNetworkOwner:
         returned_nics = owner._get_all_interfaces_info()
 
         assert returned_nics == expected_nics
+
+    def test__get_all_interfaces_info_cluster_service_unavailable(self, owner, mocker):
+        nics = [
+            WindowsInterfaceInfo(name="vSMB1", mac_address=MACAddress("00:00:00:00:00:00")),
+            WindowsInterfaceInfo(name="vSMB2", mac_address=MACAddress("00:00:00:00:00:00")),
+            WindowsInterfaceInfo(name="Ethernet 2", mac_address=MACAddress("00:00:00:00:00:00")),
+        ]
+        owner._get_interfaces_and_verify_states = mocker.Mock(return_value=nics)
+
+        mocker.patch(
+            "mfd_network_adapter.network_adapter_owner.windows.WindowsNetworkAdapterOwner._get_pci_device",
+            mocker.Mock(return_value=PCIDevice(data="8086:1572")),
+        )
+        mocker.patch(
+            "mfd_network_adapter.network_adapter_owner.windows.WindowsNetworkAdapterOwner._update_nic_if_virtual",
+            mocker.Mock(return_value=None),
+        )
+        mocker.patch(
+            "mfd_network_adapter.network_adapter_owner.windows.WindowsNetworkAdapterOwner._update_pci_addresses",
+            mocker.Mock(return_value=None),
+        )
+        mock_update_cluster = mocker.patch.object(owner, "_update_cluster")
+
+        # execute_powershell raises on Get-Cluster but succeeds for everything else
+        def _execute_powershell_side_effect(command, *args, **kwargs):
+            if "Get-Cluster" in command and "NetworkInterface" not in command:
+                raise ConnectionCalledProcessError(returncode=1, cmd=command)
+            return ConnectionCompletedProcess(return_code=0, args=command, stdout="", stderr="")
+
+        owner._connection.execute_powershell.side_effect = _execute_powershell_side_effect
+
+        # Must not raise
+        returned_nics = owner._get_all_interfaces_info()
+
+        # _update_cluster must never have been called since Get-Cluster failed
+        mock_update_cluster.assert_not_called()
+
+        # All three NICs (with mac_address set) should be returned
+        assert len(returned_nics) == 3
 
     def test_get_log_cpu_no(self, owner):
         output = dedent(


### PR DESCRIPTION
Wrap Get-Cluster execution in try/except to safely detect AShCi clusters. If the cluster service is not running, handle the error gracefully and log a debug message instead of failing.