### PR TITLE
feat: Add InterfaceType.VPORT to supported interface types for Virtualization feature

### DIFF
--- a/mfd_network_adapter/network_interface/feature/virtualization/linux.py
+++ b/mfd_network_adapter/network_interface/feature/virtualization/linux.py
@@ -31,21 +31,22 @@ class LinuxVirtualization(BaseFeatureVirtualization):
 
     def _raise_error_if_not_supported_type(self) -> None:
         """
-        Raise error in case current interface is not PF/BTS.
+        Raise error in case current interface is not PF/BTS/VPORT.
 
-        :raises VirtualizationWrongInterfaceException: if method is called on non PF/BTS interface
+        :raises VirtualizationWrongInterfaceException: if method is called on non PF/BTS/VPORT interface
         """
         current_type = self._interface().interface_type
-        if current_type not in (InterfaceType.PF, InterfaceType.BTS):
+        if current_type not in (InterfaceType.PF, InterfaceType.BTS, InterfaceType.VPORT):
             raise VirtualizationWrongInterfaceException(
-                f"Current interface type is {current_type} but should be InterfaceType.PF or InterfaceType.BTS"
+                f"Current interface type is {current_type} but should be "
+                f"InterfaceType.PF, InterfaceType.BTS or InterfaceType.VPORT"
             )
 
     def _get_vfs_details(self) -> List[VFDetail]:
         """
-        Get VF details of PF interface.
+        Get VF details of PF/BTS/VPORT interface.
 
-        :raises VirtualizationWrongInterfaceException: if method is called on non PF interface
+        :raises VirtualizationWrongInterfaceException: if method is called on non PF/BTS/VPORT interface
         :raises: VirtualizationFeatureException: in case of command failure (rc != 0)
         :return: List of VFDetail objects
         """
@@ -80,7 +81,7 @@ class LinuxVirtualization(BaseFeatureVirtualization):
         """
         Get maximal number of VFs per interface based on name.
 
-        :raises VirtualizationWrongInterfaceException if method is called on non PF interface
+        :raises VirtualizationWrongInterfaceException if method is called on non PF/BTS/VPORT interface
         :raises: VirtualizationFeatureException in case of error
         :return: number of VFs
         """
@@ -94,7 +95,7 @@ class LinuxVirtualization(BaseFeatureVirtualization):
         """
         Get maximal number of VFs per interface based on PCI Address.
 
-        :raises VirtualizationWrongInterfaceException if method is called on non PF interface
+        :raises VirtualizationWrongInterfaceException if method is called on non PF/BTS/VPORT interface
         :raises: VirtualizationFeatureException in case of error
         :return: number of VFs
         """
@@ -108,7 +109,7 @@ class LinuxVirtualization(BaseFeatureVirtualization):
         """
         Get number of current VFs per interface based on name.
 
-        :raises VirtualizationWrongInterfaceException if method is called on non PF interface
+        :raises VirtualizationWrongInterfaceException if method is called on non PF/BTS/VPORT interface
         :raises: VirtualizationFeatureException in case of error
         :return: number of VFs
         """
@@ -122,7 +123,7 @@ class LinuxVirtualization(BaseFeatureVirtualization):
         """
         Get number of current VFs per interface based on PCI Address.
 
-        :raises VirtualizationWrongInterfaceException if method is called on non PF interface
+        :raises VirtualizationWrongInterfaceException if method is called on non PF/BTS/VPORT interface
         :raises: VirtualizationFeatureException in case of error
         :return: number of VFs
         """
@@ -201,7 +202,7 @@ class LinuxVirtualization(BaseFeatureVirtualization):
 
         :param: vf_id: VF (virtual function) ID
         :param value: max_tx_rate value (Mbits)
-        :raises VirtualizationWrongInterfaceException if method is called on non PF interface
+        :raises VirtualizationWrongInterfaceException if method is called on non PF/BTS/VPORT interface
         :raises VirtualizationFeatureException if command execution fails
         """
         self._raise_error_if_not_supported_type()
@@ -216,7 +217,7 @@ class LinuxVirtualization(BaseFeatureVirtualization):
 
         :param vf_id: VF (virtual function) ID
         :param value: min_tx_rate value (Mbits)
-        :raises VirtualizationWrongInterfaceException if method is called on non PF interface
+        :raises VirtualizationWrongInterfaceException if method is called on non PF/BTS/VPORT interface
         :raises VirtualizationFeatureException if command execution fails
         """
         self._raise_error_if_not_supported_type()
@@ -230,7 +231,7 @@ class LinuxVirtualization(BaseFeatureVirtualization):
 
         :param vf_id: Virtual Function ID
         :param state: State to be set: Enabled or Disabled (On/Off)
-        :raises VirtualizationWrongInterfaceException if method is called on non PF interface
+        :raises VirtualizationWrongInterfaceException if method is called on non PF/BTS/VPORT interface
         :raises: VirtualizationFeatureException in case of command error
         """
         self._raise_error_if_not_supported_type()
@@ -246,7 +247,7 @@ class LinuxVirtualization(BaseFeatureVirtualization):
         Turning off spoofchk allows the VF to change its MAC address.
         :param vf_id: Virtual Function ID
         :param state: State to be set: Enabled or Disabled (On/Off)
-        :raises VirtualizationWrongInterfaceException if method is called on non PF interface
+        :raises VirtualizationWrongInterfaceException if method is called on non PF/BTS/VPORT interface
         :raises: VirtualizationFeatureException in case of error
         """
         self._raise_error_if_not_supported_type()
@@ -260,7 +261,7 @@ class LinuxVirtualization(BaseFeatureVirtualization):
         Get trust setting per VF.
 
         :param vf_id: Virtual Function ID
-        :raises VirtualizationWrongInterfaceException if method is called on non PF interface
+        :raises VirtualizationWrongInterfaceException if method is called on non PF/BTS/VPORT interface
         :return: State of trust setting
         """
         for vf in self._get_vfs_details():
@@ -272,7 +273,7 @@ class LinuxVirtualization(BaseFeatureVirtualization):
         Get spoofhck setting per VF.
 
         :param vf_id: Virtual Function ID
-        :raises VirtualizationWrongInterfaceException if method is called on non PF interface
+        :raises VirtualizationWrongInterfaceException if method is called on non PF/BTS/VPORT interface
         :return: State of spoofhck setting
         """
         for vf in self._get_vfs_details():
@@ -284,7 +285,7 @@ class LinuxVirtualization(BaseFeatureVirtualization):
         Get mac_address per VF.
 
         :param vf_id: Virtual Function ID
-        :raises VirtualizationWrongInterfaceException: if method is called on non PF interface
+        :raises VirtualizationWrongInterfaceException: if method is called on non PF/BTS/VPORT interface
         :return: Mac Address of VF
         """
         for vf in self._get_vfs_details():
@@ -296,7 +297,7 @@ class LinuxVirtualization(BaseFeatureVirtualization):
         Get link-state per VF.
 
         :param vf_id: Virtual Function ID
-        :raises VirtualizationWrongInterfaceException: if method is called on non PF interface
+        :raises VirtualizationWrongInterfaceException: if method is called on non PF/BTS/VPORT interface
         :return: Link State setting of VF
         """
         for vf in self._get_vfs_details():
@@ -310,7 +311,7 @@ class LinuxVirtualization(BaseFeatureVirtualization):
         :param vf_id: Virtual Function ID
         :param vlan_id: VLAN to set the VF to
         :param proto: Specify 802.1ad or 802.1Q type of VLAN
-        :raises VirtualizationWrongInterfaceException if method is called on non PF interface
+        :raises VirtualizationWrongInterfaceException if method is called on non PF/BTS/VPORT interface
         :raises: VirtualizationFeatureException in case of error
         """
         self._raise_error_if_not_supported_type()
@@ -324,7 +325,7 @@ class LinuxVirtualization(BaseFeatureVirtualization):
 
         :param vf_id: Virtual Function ID
         :param link_state: requested link state (one of auto, enabled, disabled)
-        :raises VirtualizationWrongInterfaceException if method is called on non PF interface
+        :raises VirtualizationWrongInterfaceException if method is called on non PF/BTS/VPORT interface
         :raises: VirtualizationFeatureException in case of error
         """
         self._raise_error_if_not_supported_type()

--- a/tests/unit/test_mfd_network_adapter/test_network_interface/test_feature/test_virtualization/test_virtualization_linux.py
+++ b/tests/unit/test_mfd_network_adapter/test_network_interface/test_feature/test_virtualization/test_virtualization_linux.py
@@ -160,6 +160,10 @@ class TestVirtualizationLinux:
         interface._interface_info.interface_type = InterfaceType.BTS
         assert interface.virtualization._raise_error_if_not_supported_type() is None
 
+    def test__raise_error_if_not_pf_passes_vport(self, interface):
+        interface._interface_info.interface_type = InterfaceType.VPORT
+        assert interface.virtualization._raise_error_if_not_supported_type() is None
+
     def test_set_link_for_vf_pass(self, interface, mocker):
         interface._interface_info.name = "foo"
         vf_id = 2


### PR DESCRIPTION
This pull request expands the supported interface types for virtualization features in `linux.py` to include `VPORT`, in addition to the existing `PF` and `BTS` types. It updates both the implementation and all related docstrings to reflect this change, and adds a new unit test to verify the new behavior.

**Support for VPORT interface type:**

* Updated `_raise_error_if_not_supported_type` to allow `VPORT` as a supported interface type, alongside `PF` and `BTS` (`linux.py`).
* Modified all relevant method docstrings in `linux.py` to indicate that `VirtualizationWrongInterfaceException` is now raised for non-`PF`/`BTS`/`VPORT` interfaces, instead of just non-`PF` interfaces. [[1]](diffhunk://#diff-fb1b1dc142f38640597cd713c193ad7521c17bc2d12eb640e63c61e809a8806eL48-R48) [[2]](diffhunk://#diff-fb1b1dc142f38640597cd713c193ad7521c17bc2d12eb640e63c61e809a8806eL83-R83) [[3]](diffhunk://#diff-fb1b1dc142f38640597cd713c193ad7521c17bc2d12eb640e63c61e809a8806eL97-R97) [[4]](diffhunk://#diff-fb1b1dc142f38640597cd713c193ad7521c17bc2d12eb640e63c61e809a8806eL111-R111) [[5]](diffhunk://#diff-fb1b1dc142f38640597cd713c193ad7521c17bc2d12eb640e63c61e809a8806eL125-R125) [[6]](diffhunk://#diff-fb1b1dc142f38640597cd713c193ad7521c17bc2d12eb640e63c61e809a8806eL204-R204) [[7]](diffhunk://#diff-fb1b1dc142f38640597cd713c193ad7521c17bc2d12eb640e63c61e809a8806eL219-R219) [[8]](diffhunk://#diff-fb1b1dc142f38640597cd713c193ad7521c17bc2d12eb640e63c61e809a8806eL233-R233) [[9]](diffhunk://#diff-fb1b1dc142f38640597cd713c193ad7521c17bc2d12eb640e63c61e809a8806eL249-R249) [[10]](diffhunk://#diff-fb1b1dc142f38640597cd713c193ad7521c17bc2d12eb640e63c61e809a8806eL263-R263) [[11]](diffhunk://#diff-fb1b1dc142f38640597cd713c193ad7521c17bc2d12eb640e63c61e809a8806eL275-R275) [[12]](diffhunk://#diff-fb1b1dc142f38640597cd713c193ad7521c17bc2d12eb640e63c61e809a8806eL287-R287) [[13]](diffhunk://#diff-fb1b1dc142f38640597cd713c193ad7521c17bc2d12eb640e63c61e809a8806eL299-R299) [[14]](diffhunk://#diff-fb1b1dc142f38640597cd713c193ad7521c17bc2d12eb640e63c61e809a8806eL313-R313) [[15]](diffhunk://#diff-fb1b1dc142f38640597cd713c193ad7521c17bc2d12eb640e63c61e809a8806eL327-R327)

**Testing:**

* Added a new unit test `test__raise_error_if_not_pf_passes_vport` to ensure that `VPORT` is accepted as a valid interface type for virtualization features (`test_virtualization_linux.py`).